### PR TITLE
chore: import repository https://github.com/entando-k8s/entando-k8s-operator-common.git

### DIFF
--- a/.jx/gitops/source-config.yaml
+++ b/.jx/gitops/source-config.yaml
@@ -1,0 +1,16 @@
+apiVersion: gitops.jenkins-x.io/v1alpha1
+kind: SourceConfig
+metadata:
+  creationTimestamp: null
+spec:
+  groups:
+  - owner: entando-k8s
+    provider: https://github.com
+    providerKind: github
+    repositories:
+    - name: entando-k8s-operator-common
+    scheduler: in-repo
+  slack:
+    channel: '#jenkins-x-pipelines'
+    kind: failureOrNextSuccess
+    pipeline: release

--- a/config-root/namespaces/jx/lighthouse-config/config-cm.yaml
+++ b/config-root/namespaces/jx/lighthouse-config/config-cm.yaml
@@ -7,6 +7,7 @@ data:
       LinkURL: null
     in_repo_config:
       enabled:
+        entando-k8s/entando-k8s-operator-common: true
         entando-k8s/jx3-azure-akv: true
     plank: {}
     pod_namespace: jx
@@ -19,6 +20,7 @@ data:
         required-if-present-contexts: null
         skip-unknown-contexts: false
       merge_method:
+        entando-k8s/entando-k8s-operator-common: merge
         entando-k8s/jx3-azure-akv: merge
       queries:
       - labels:
@@ -31,6 +33,7 @@ data:
         - needs-rebase
         repos:
         - entando-k8s/jx3-azure-akv
+        - entando-k8s/entando-k8s-operator-common
       - labels:
         - updatebot
         missingLabels:
@@ -41,6 +44,7 @@ data:
         - needs-rebase
         repos:
         - entando-k8s/jx3-azure-akv
+        - entando-k8s/entando-k8s-operator-common
       target_url: http://lighthouse-jx.jx.entando.io/merge/status
 kind: ConfigMap
 metadata:

--- a/config-root/namespaces/jx/lighthouse-config/plugins-cm.yaml
+++ b/config-root/namespaces/jx/lighthouse-config/plugins-cm.yaml
@@ -6,6 +6,10 @@ data:
       repos:
       - entando-k8s/jx3-azure-akv
       require_self_approval: true
+    - lgtm_acts_as_approve: true
+      repos:
+      - entando-k8s/entando-k8s-operator-common
+      require_self_approval: true
     cat: {}
     cherry_pick_unapproved: {}
     config_updater:
@@ -16,6 +20,11 @@ data:
         env/prow/plugins.yaml:
           name: plugins
     external_plugins:
+      entando-k8s/entando-k8s-operator-common:
+      - endpoint: http://cd-indicators.jx.svc.cluster.local/lighthouse/events
+        name: cd-indicators
+      - endpoint: http://lighthouse-webui-plugin.jx.svc.cluster.local/lighthouse/events
+        name: lighthouse-webui-plugin
       entando-k8s/jx3-azure-akv:
       - endpoint: http://cd-indicators.jx.svc.cluster.local/lighthouse/events
         name: cd-indicators
@@ -26,6 +35,22 @@ data:
       additional_labels: null
     owners: {}
     plugins:
+      entando-k8s/entando-k8s-operator-common:
+      - approve
+      - assign
+      - blunderbuss
+      - help
+      - hold
+      - lgtm
+      - lifecycle
+      - override
+      - size
+      - trigger
+      - wip
+      - heart
+      - cat
+      - dog
+      - pony
       entando-k8s/jx3-azure-akv:
       - config-updater
       - approve
@@ -55,6 +80,11 @@ data:
     - repos:
       - entando-k8s/jx3-azure-akv
       trusted_org: todo
+    - repos:
+      - entando-k8s/entando-k8s-operator-common
+      trusted_org: todo
+    welcome:
+    - message_template: Welcome
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/config-root/namespaces/jx/lighthouse/lighthouse-foghorn-deploy.yaml
+++ b/config-root/namespaces/jx/lighthouse/lighthouse-foghorn-deploy.yaml
@@ -21,7 +21,7 @@ spec:
       labels:
         app: lighthouse-foghorn
       annotations:
-        jenkins-x.io/hash: '1a9ebfe8a5e766072fe53cae6b16f7fe1abfbac3a91945f34217d5ee9d3eb4bc'
+        jenkins-x.io/hash: '91ee14b4bca1e3668fe3a78a8d8678863a0279fef36a21a4a4dd6204d478943a'
     spec:
       serviceAccountName: lighthouse-foghorn
       containers:

--- a/config-root/namespaces/jx/lighthouse/lighthouse-keeper-deploy.yaml
+++ b/config-root/namespaces/jx/lighthouse/lighthouse-keeper-deploy.yaml
@@ -27,7 +27,7 @@ spec:
         ad.datadoghq.com/keeper.logs: '[{"source":"lighthouse","service":"keeper"}]'
         prometheus.io/port: "9090"
         prometheus.io/scrape: "true"
-        jenkins-x.io/hash: '1a9ebfe8a5e766072fe53cae6b16f7fe1abfbac3a91945f34217d5ee9d3eb4bc'
+        jenkins-x.io/hash: '91ee14b4bca1e3668fe3a78a8d8678863a0279fef36a21a4a4dd6204d478943a'
       labels:
         app: lighthouse-keeper
     spec:

--- a/config-root/namespaces/jx/lighthouse/lighthouse-tekton-controller-deploy.yaml
+++ b/config-root/namespaces/jx/lighthouse/lighthouse-tekton-controller-deploy.yaml
@@ -20,7 +20,7 @@ spec:
     metadata:
       labels:
         app: lighthouse-tekton-controller
-      annotations: {jenkins-x.io/hash: '1a9ebfe8a5e766072fe53cae6b16f7fe1abfbac3a91945f34217d5ee9d3eb4bc'}
+      annotations: {jenkins-x.io/hash: '91ee14b4bca1e3668fe3a78a8d8678863a0279fef36a21a4a4dd6204d478943a'}
     spec:
       serviceAccountName: lighthouse-tekton-controller
       containers:

--- a/config-root/namespaces/jx/lighthouse/lighthouse-webhooks-deploy.yaml
+++ b/config-root/namespaces/jx/lighthouse/lighthouse-webhooks-deploy.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         prometheus.io/port: "2112"
         prometheus.io/scrape: "true"
-        jenkins-x.io/hash: '1a9ebfe8a5e766072fe53cae6b16f7fe1abfbac3a91945f34217d5ee9d3eb4bc'
+        jenkins-x.io/hash: '91ee14b4bca1e3668fe3a78a8d8678863a0279fef36a21a4a4dd6204d478943a'
     spec:
       serviceAccountName: lighthouse-webhooks
       containers:

--- a/config-root/namespaces/jx/source-repositories/entando-k8s-entando-k8s-operator-common.yaml
+++ b/config-root/namespaces/jx/source-repositories/entando-k8s-entando-k8s-operator-common.yaml
@@ -1,0 +1,22 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: entando-k8s
+    provider: github
+    repository: entando-k8s-operator-common
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  name: entando-k8s-entando-k8s-operator-common
+  namespace: jx
+spec:
+  httpCloneURL: https://github.com/entando-k8s/entando-k8s-operator-common.git
+  org: entando-k8s
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: entando-k8s-operator-common
+  scheduler:
+    kind: ""
+    name: in-repo
+  url: https://github.com/entando-k8s/entando-k8s-operator-common


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the CI/CD configuration](https://jenkins-x.io/docs/v3/about/how-it-works/#importing--creating-quickstarts) which will create a second commit on this Pull Request before it auto merges
